### PR TITLE
GitHub Actionsがうまく動作しなくなっていたので修正

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: build pdf and upload release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,10 +10,10 @@ jobs:
     name: build pdf and upload release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - name: build pdf
         run: npm run build:pdf

--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -9,7 +9,7 @@ jobs:
     name: create issue
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-issue.yml
+++ b/.github/workflows/create-issue.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: create issue
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: JasonEtco/create-an-issue@v2

--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: lint text
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2-beta

--- a/.github/workflows/lint-text.yml
+++ b/.github/workflows/lint-text.yml
@@ -7,10 +7,10 @@ jobs:
     name: lint text
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install
       - name: lint text
         run: npm run lint

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "husky": "^5.0.0-alpha.6",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "^1.0.1",
-    "md-to-pdf": "^3.1.1",
+    "md-to-pdf": "^5.2.4",
     "textlint": "^11.6.3",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-filter-rule-whitelist": "^2.0.0",


### PR DESCRIPTION
## 概要
GitHub Actionsをトリガーした時にワークフローが"queued"ステータスのままでいつまで経っても実行されなくなっていた．このPRではそのバグを修正しています．

## バグの原因
ランナーにUbuntu 18.04を使用していることが原因であると特定しました．Ubuntu 18.04は2022年12月1日をもってGitHub Actionsのランナーイメージとしてサポートされなくなったようです．

> [GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

## 解決策
これを解決するために，ランナーイメージを**Ubuntu 22.04**へと更新させました．これによりワークフローが"queued"ステータスのまま実行されない状態が解決され，ワークフローが実行されるようになります．

また，上記の問題が解決された後，今度は`build-pdf.yml`ファイルの`run: npm run build:pdf`が永遠に終わらないバグを発見しました．このバグを解決するために，ワークフローファイルの微修正と`md-to-pdf`パッケージのバージョンをあげることで動作するよう修正しました．
